### PR TITLE
New pathfinder

### DIFF
--- a/controller.ts
+++ b/controller.ts
@@ -242,10 +242,9 @@ export class ControllerPlugin extends BaseControllerPlugin {
 			});
 			new_solution = [...destinations.values()].map(dest => [...dest.reachable_targets.entries()].map(([key, value]) => `${key}:${value}`).join(",")).join(";");
 		}
-		console.log(new_solution);
 
 		// Log if we hit the iteration limit
-		this.logger.info(`Pathfinder iterations: ${iterations}`);
+		// this.logger.info(`Pathfinder iterations: ${iterations}`); // Add prometheus metric for this
 		if (iterations >= 100) {
 			this.logger.warn("Pathfinder hit iteration limit");
 		}
@@ -257,8 +256,6 @@ export class ControllerPlugin extends BaseControllerPlugin {
 			});
 		});
 
-		console.log(destinations);
-
 		// Send updates to instances
 		destinations.forEach((dest) => {
 			const split = dest.id.split(" ");
@@ -269,8 +266,6 @@ export class ControllerPlugin extends BaseControllerPlugin {
 				this.logger.warn(`Edge ${edgeId} not found for pathfinder update`);
 				return;
 			}
-			const link = edge.link_destinations[offset];
-			link.reachable_targets = Array.from(dest.reachable_targets.keys());
 
 			this.controller.sendTo({ instanceId: dest.source_instance_id }, new messages.EdgeLinkUpdate(edgeId, "update_train_penalty_map", {
 				offset: Number(offset),

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,7 @@ export const plugin: lib.PluginDeclaration = {
 		messages.EdgeTransfer,
 		messages.EdgeUpdate,
 		messages.SetEdgeConfig,
+		messages.TrainLayoutUpdate,
 	],
 
 	webEntrypoint: "./web",

--- a/instance.ts
+++ b/instance.ts
@@ -217,7 +217,7 @@ export class InstancePlugin extends BaseInstancePlugin {
 
 	async onStart() {
 		this.logger.info("instance::onStart");
-		this.sendRcon(`/sc universal_edges.set_config({instance_id = ${this.instance.config.get("instance.id")}})`);
+		await this.sendRcon(`/sc universal_edges.set_config({instance_id = ${this.instance.config.get("instance.id")}})`);
 	}
 
 	async onStop() {
@@ -355,7 +355,7 @@ export class InstancePlugin extends BaseInstancePlugin {
 				edgeBuffer.edge = edge;
 			}
 			// Update ingame config
-			this.sendRcon(`/sc universal_edges.edge_update("${edge.id}", '${lib.escapeString(JSON.stringify(edge))}')`);
+			await this.sendRcon(`/sc universal_edges.edge_update("${edge.id}", '${lib.escapeString(JSON.stringify(edge))}')`);
 
 			// Update edge callbacks
 			let callbacks = this.edgeCallbacks.get(edge.id);

--- a/messages.ts
+++ b/messages.ts
@@ -47,7 +47,7 @@ export class SetEdgeConfig {
 export class EdgeLinkUpdate {
 	declare ["constructor"]: typeof EdgeLinkUpdate;
 	static type = "event" as const;
-	static src = "instance" as const;
+	static src = ["controller", "instance"] as const;
 	static dst = "instance" as const;
 	static plugin = "universal_edges" as const;
 
@@ -61,6 +61,40 @@ export class EdgeLinkUpdate {
 
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(json.edgeId, json.type, json.data);
+	}
+}
+
+export class TrainLayoutUpdate {
+	declare ["constructor"]: typeof TrainLayoutUpdate;
+	static type = "event" as const;
+	static src = "instance" as const;
+	static dst = "controller" as const;
+	static plugin = "universal_edges" as const;
+
+	constructor(public edgeId: string, public data: {
+		offset: number,
+		reachable_targets: string[], // backer_name for internal stations
+		reachable_sources: string[] // edge_id + offset for exits (sources)
+		source_instance_id: number,
+	}) { }
+
+	static jsonSchema = Type.Object({
+		edgeId: Type.String(),
+		data: Type.Object({
+			offset: Type.Number(),
+			reachable_targets: Type.Array(Type.String()),
+			reachable_sources: Type.Array(Type.String()),
+			source_instance_id: Type.Number(),
+		}),
+	});
+
+	static fromJSON(json: Static<typeof this.jsonSchema>) {
+		return new this(json.edgeId, {
+			offset: json.data.offset,
+			reachable_targets: json.data.reachable_targets,
+			reachable_sources: json.data.reachable_sources,
+			source_instance_id: json.data.source_instance_id,
+		});
 	}
 }
 

--- a/mod/entity/trains.lua
+++ b/mod/entity/trains.lua
@@ -8,3 +8,16 @@
 
 -- Defaults to 1000
 data.raw["utility-constants"]["default"].train_path_finding["signal_reserved_by_circuit_network_penalty"] = 100000
+
+-- We create our own train-stop prototypes to be able to differentiate between normal train-stops, source connector trainstops and proxy trainstops placed at the source connector.
+
+local source_trainstop = table.deepcopy(data.raw["train-stop"]["train-stop"])
+source_trainstop.name = "ue_source_trainstop"
+
+local proxy_trainstop = table.deepcopy(data.raw["train-stop"]["train-stop"])
+proxy_trainstop.name = "ue_proxy_trainstop"
+proxy_trainstop.chart_name = false -- Prevent from showing up on map, just overlaps anyways
+
+log("Adding trainstops")
+
+data:extend { source_trainstop, proxy_trainstop }

--- a/mod/info.json
+++ b/mod/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "universal_edges",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"title": "Clusterio universal edges",
 	"author": "Danielv123",
 	"factorio_version": "1.1",

--- a/mod/locale/en/locale.cfg
+++ b/mod/locale/en/locale.cfg
@@ -15,6 +15,8 @@ edge_pipe_horizontal=Horizontal fluid edge
 ue_eei_input=Discharging accumulators
 ue_eei_output=Charging accumulators
 ue_eei_tertiary=Storage mode
+ue_source_trainstop=Universal edges source trainstop
+ue_proxy_trainstop=Proxy trainstop
 
 [entity-description]
 edge_pipe_vertical=Vertical pipe for universal edges fluid transport

--- a/module/control.lua
+++ b/module/control.lua
@@ -24,7 +24,7 @@ local universal_edges = {
 }
 
 local function setupGlobalData()
-	local GLOBAL_VERSION = 1
+	local GLOBAL_VERSION = 2
 	if global.universal_edges == nil
 		or global.universal_edges.GLOBAL_VERSION == nil
 		or global.universal_edges.GLOBAL_VERSION < GLOBAL_VERSION
@@ -42,6 +42,8 @@ local function setupGlobalData()
 			edges = {},
 			debug_shapes = {},
 			config = {},
+			edge_trainstops = {}, -- Track edge trainstops for faster pathfinder lookups
+			edge_source_stops = {}, -- Track edge source stops for faster pathfinder lookups
 			GLOBAL_VERSION = GLOBAL_VERSION,
 		}
 	end

--- a/module/control.lua
+++ b/module/control.lua
@@ -42,8 +42,6 @@ local function setupGlobalData()
 			edges = {},
 			debug_shapes = {},
 			config = {},
-			edge_trainstops = {}, -- Track edge trainstops for faster pathfinder lookups
-			edge_source_trainstops = {}, -- Track edge source stops for faster pathfinder lookups
 			GLOBAL_VERSION = GLOBAL_VERSION,
 		}
 	end

--- a/module/control.lua
+++ b/module/control.lua
@@ -24,7 +24,7 @@ local universal_edges = {
 }
 
 local function setupGlobalData()
-	local GLOBAL_VERSION = 2
+	local GLOBAL_VERSION = 3
 	if global.universal_edges == nil
 		or global.universal_edges.GLOBAL_VERSION == nil
 		or global.universal_edges.GLOBAL_VERSION < GLOBAL_VERSION
@@ -43,7 +43,7 @@ local function setupGlobalData()
 			debug_shapes = {},
 			config = {},
 			edge_trainstops = {}, -- Track edge trainstops for faster pathfinder lookups
-			edge_source_stops = {}, -- Track edge source stops for faster pathfinder lookups
+			edge_source_trainstops = {}, -- Track edge source stops for faster pathfinder lookups
 			GLOBAL_VERSION = GLOBAL_VERSION,
 		}
 	end

--- a/module/edge/train/pathfinding/update.lua
+++ b/module/edge/train/pathfinding/update.lua
@@ -45,7 +45,7 @@ local function update_connector_paths(edge, offset, link)
 	end
 
 	local edge_target = edge_util.edge_get_local_target(edge)
-	local train_stops = game.surfaces[1].find_entities_filtered {
+	local train_stops = game.surfaces[edge_util.edge_get_local_target(edge).surface].find_entities_filtered {
 		type = "train-stop"
 	}
 	local targets = {}
@@ -59,13 +59,15 @@ local function update_connector_paths(edge, offset, link)
 				targets[#targets + 1] = {
 					train_stop = stop
 				}
+				-- Log position and backer_name
+				log("Found trainstop at " .. serpent.block(stop.position) .. " with name " .. stop.backer_name)
 			end
 			-- If this is a source stop
-			if global.universal_edges.edge_source_trainstops[stop.unit_number] ~= nil then
+		if global.universal_edges.edge_source_trainstops[stop.unit_number] ~= nil then
 				sources[#sources + 1] = {
 					train_stop = stop,
 				}
-				source_ids[#source_ids + 1] = edge.id .. " " .. offset
+				source_ids[#source_ids + 1] = global.universal_edges.edge_source_trainstops[stop.unit_number].edge.id .. " " .. global.universal_edges.edge_source_trainstops[stop.unit_number].offset
 			end
 		end
 	end
@@ -289,7 +291,7 @@ local function update_train_penalty_map(offset, edge, penalty_map)
 			}
 			if stop ~= nil then
 				-- Track for easier pathfinding lookups
-				global.universal_edges.edge_source_trainstops[stop.unit_number] = {
+				global.universal_edges.edge_trainstops[stop.unit_number] = {
 					stop = stop,
 					edge = edge,
 					offset = offset,

--- a/module/edge/train/train_box.lua
+++ b/module/edge/train/train_box.lua
@@ -47,17 +47,11 @@ local function create_train_source_box(offset, edge, surface)
 	end
 
 	local stop = surface.create_entity {
-		name = "train-stop",
+		name = "ue_source_trainstop",
 		position = edge_util.edge_pos_to_world({ edge_x + 2, -3 }, edge),
 		direction = edge_target.direction,
 	}
-	-- Track for easier pathfinding lookups
-	global.universal_edges.edge_source_trainstops[stop.unit_number] = {
-		stop = stop,
-		edge = edge,
-		offset = offset,
-	}
-	global.universal_edges.edge_trainstops[stop.unit_number] = global.universal_edges.edge_source_trainstops[stop.unit_number]
+	stop.backer_name = edge.id .. " " .. offset
 	local signal = surface.create_entity {
 		name = "rail-signal",
 		position = edge_util.edge_pos_to_world({ edge_x + 1.5, -0.5 }, edge),
@@ -103,13 +97,6 @@ local function remove_train_source_box(offset, edge, _surface)
 		if link.penalty_rails ~= nil then
 			for _index, rail in pairs(link.penalty_rails) do
 				if rail and rail.valid then
-					-- dereference
-					if global.universal_edges.edge_source_trainstops[rail.unit_number] then
-						global.universal_edges.edge_source_trainstops[rail.unit_number] = nil
-					end
-					if global.universal_edges.edge_trainstops[rail.unit_number] then
-						global.universal_edges.edge_trainstops[rail.unit_number] = nil
-					end
 					rail.destroy()
 				end
 			end

--- a/module/edge/train/train_box.lua
+++ b/module/edge/train/train_box.lua
@@ -172,7 +172,7 @@ local function create_train_destination_box(offset, edge, surface, update)
 			"straight-rail",
 			edge_util.edge_pos_to_world({ edge_x, 1 - i * 2 }, edge)
 		)
-		if rail.direction == edge_target.direction then
+		if rail ~= nil and rail.direction == edge_target.direction then
 			rails[#rails + 1] = rail
 			-- Skip creating new rail
 		else

--- a/module/edge/train/train_box.lua
+++ b/module/edge/train/train_box.lua
@@ -51,6 +51,13 @@ local function create_train_source_box(offset, edge, surface)
 		position = edge_util.edge_pos_to_world({ edge_x + 2, -3 }, edge),
 		direction = edge_target.direction,
 	}
+	-- Track for easier pathfinding lookups
+	global.universal_edges.edge_source_trainstops[stop.unit_number] = {
+		stop = stop,
+		edge = edge,
+		offset = offset,
+	}
+	global.universal_edges.edge_trainstops[stop.unit_number] = global.universal_edges.edge_source_trainstops[stop.unit_number]
 	local signal = surface.create_entity {
 		name = "rail-signal",
 		position = edge_util.edge_pos_to_world({ edge_x + 1.5, -0.5 }, edge),
@@ -96,6 +103,13 @@ local function remove_train_source_box(offset, edge, _surface)
 		if link.penalty_rails ~= nil then
 			for _index, rail in pairs(link.penalty_rails) do
 				if rail and rail.valid then
+					-- dereference
+					if global.universal_edges.edge_source_trainstops[rail.unit_number] then
+						global.universal_edges.edge_source_trainstops[rail.unit_number] = nil
+					end
+					if global.universal_edges.edge_trainstops[rail.unit_number] then
+						global.universal_edges.edge_trainstops[rail.unit_number] = nil
+					end
 					rail.destroy()
 				end
 			end

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "Plugin for seamless belts, fluids, electricity and trains between clusterio instances",
 	"main": "dist/node/index.js",
 	"scripts": {
-		"prepare": "tsc --build ./tsconfig.node.json && webpack-cli --env production",
+		"prepare": "tsc --build ./tsconfig.node.json && webpack-cli --env production && node ./build.js",
+		"buildmod": "node ./build.js",
 		"watch": "tsc --build --watch",
 		"cloc": "cloc --exclude-dir=node_modules,dist .",
 		"lint": "eslint \"*.ts\" './src/**/*' web/**/* --fix",
@@ -15,33 +16,30 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/web_ui": "^2.0.0-alpha.17",
-		"@clusterio/lib": "^2.0.0-alpha.17",
-		"@clusterio/controller": "^2.0.0-alpha.17",
-		"@clusterio/host": "^2.0.0-alpha.17"
+		"@clusterio/controller": "^2.0.0-alpha.0",
+		"@clusterio/host": "^2.0.0-alpha.0",
+		"@clusterio/lib": "^2.0.0-alpha.0",
+		"@clusterio/web_ui": "^2.0.0-alpha.0"
 	},
 	"devDependencies": {
 		"@ant-design/icons": "^5.3.7",
 		"@swc/wasm": "^1.5.24",
-		"@typescript-eslint/eslint-plugin": "^7.11.0",
-		"@typescript-eslint/parser": "^7.11.0",
-		"typescript": "^5.1.6",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
+		"@typescript-eslint/eslint-plugin": "^7.11.0",
+		"@typescript-eslint/parser": "^7.11.0",
 		"antd": "^5.13.0",
 		"eslint": "^8.4.1",
 		"eslint-plugin-node": "^11.1.0",
+		"klaw": "^4.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.23.1",
 		"spaces-to-tabs": "^0.0.3",
+		"typescript": "^5.1.6",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
-		"webpack-merge": "^5.9.0",
-		"@clusterio/web_ui": "^2.0.0-alpha.17",
-		"@clusterio/lib": "^2.0.0-alpha.17",
-		"@clusterio/controller": "^2.0.0-alpha.17",
-		"@clusterio/host": "^2.0.0-alpha.17"
+		"webpack-merge": "^5.9.0"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4"

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -8,6 +8,11 @@ export interface Edge {
 	target: EdgeTargetSpecification;
 	length: number;
 	active: boolean;
+	link_destinations: Record<string, { // keys is offset as a string
+		reachable_targets: string[];
+		reachable_sources: string[];
+		source_instance_id: number;
+	}>;
 }
 
 export interface EdgeTargetSpecification {
@@ -16,18 +21,6 @@ export interface EdgeTargetSpecification {
 	surface: number;
 	direction: number;
 	ready: boolean;
-}
-
-
-export interface EdgeConnector {
-	position: number; // Distance along edge from origin
-	type: "InBelt" | "OutBelt" | "InTrain" | "OutTrain" | "Fluid" | "Power";
-	sourcePlaced: boolean,
-	targetPlaced: boolean,
-	blocked: number; // 0 means blocked, numerical value is the amount of items that can pass
-	// Buffers for fluids and power
-	sourceBuffer?: TwoWayBuffer;
-	targetBuffer?: TwoWayBuffer;
 }
 
 export interface TwoWayBuffer {
@@ -80,5 +73,9 @@ export const Edge = Type.Object({
 	target: EdgeTarget,
 	length: Type.Number(),
 	active: Type.Boolean(),
-	connectors: Type.Optional(Type.Array(EdgeConnector)),
+	link_destinations: Type.Record(Type.String(), Type.Object({
+		reachable_targets: Type.Array(Type.String()),
+		reachable_sources: Type.Array(Type.String()),
+		source_instance_id: Type.Number(),
+	})),
 });


### PR DESCRIPTION
Run inter-server pathfinding on the controller instead of relying on path propagation between the instances. By calculating the entire path in a single shot it reaches stability faster while also allowing for removing trainstops.